### PR TITLE
Fix to incorrect Center Crop scale being applied due to incorrect cas…

### DIFF
--- a/app/src/main/java/com/yperess/stackoverflow/MovieWallpaperRenderer.kt
+++ b/app/src/main/java/com/yperess/stackoverflow/MovieWallpaperRenderer.kt
@@ -281,8 +281,7 @@ class MovieWallpaperRenderer(
                     +1f, -1f, 0f,
                     +1f, +1f, 0f)
             MovieLiveWallpaperService.Mode.CENTER_CROP -> {
-                val maxScale = Math.max(surfaceWidth / videoWidth, surfaceHeight / videoHeight)
-                        .toFloat()
+                val maxScale = Math.max(surfaceWidth / videoWidth.toFloat(), surfaceHeight / videoHeight.toFloat())
                 val width = videoWidth * maxScale / surfaceWidth
                 val height = videoHeight * maxScale / surfaceHeight
                 floatArrayOf(


### PR DESCRIPTION
…ting from Int to Float

The scale was being applied incorrectly, and resulting in truncated integer values. IE a required scale of 2.5 would instead be 2.0